### PR TITLE
Update type definitions in the `encoding` package

### DIFF
--- a/plugin/exporter/idb/cockroach/internal/encoding/encoding.go
+++ b/plugin/exporter/idb/cockroach/internal/encoding/encoding.go
@@ -94,13 +94,17 @@ func unconvertExpiredAccounts(accounts []AlgodEncodedAddress) []sdk.Address {
 func convertBlockHeader(header sdk.BlockHeader) blockHeader {
 	return blockHeader{
 		BlockHeader:                          header,
+		ProposerOverride:                     AlgodEncodedAddress(header.Proposer),
 		ExpiredParticipationAccountsOverride: convertExpiredAccounts(header.ExpiredParticipationAccounts),
+		AbsentParticipationAccountsOverride:  convertExpiredAccounts(header.AbsentParticipationAccounts),
 	}
 }
 
 func unconvertBlockHeader(header blockHeader) sdk.BlockHeader {
 	res := header.BlockHeader
+	res.Proposer = sdk.Address(header.ProposerOverride)
 	res.ExpiredParticipationAccounts = unconvertExpiredAccounts(header.ExpiredParticipationAccountsOverride)
+	res.AbsentParticipationAccounts = unconvertExpiredAccounts(header.AbsentParticipationAccountsOverride)
 	return res
 }
 
@@ -359,6 +363,7 @@ func unconvertTrimmedAccountData(ad trimmedAccountData) sdk.AccountData {
 			RewardsBase:         ad.RewardsBase,
 			RewardedMicroAlgos:  sdk.MicroAlgos(ad.RewardedMicroAlgos),
 			AuthAddr:            ad.AuthAddr,
+			IncentiveEligible:   ad.IncentiveEligible,
 			TotalAppSchema:      ad.TotalAppSchema,
 			TotalExtraAppPages:  ad.TotalExtraAppPages,
 			TotalAppParams:      ad.TotalAppParams,
@@ -367,6 +372,8 @@ func unconvertTrimmedAccountData(ad trimmedAccountData) sdk.AccountData {
 			TotalAssets:         ad.TotalAssets,
 			TotalBoxes:          ad.TotalBoxes,
 			TotalBoxBytes:       ad.TotalBoxBytes,
+			LastProposed:        ad.LastProposed,
+			LastHeartbeat:       ad.LastHeartbeat,
 		},
 		VotingData: sdk.VotingData{
 			VoteID:          ad.VoteID,
@@ -648,6 +655,7 @@ func convertTrimmedLcAccountData(ad sdk.AccountData) baseAccountData {
 	return baseAccountData{
 		Status:              ad.Status,
 		AuthAddr:            ad.AuthAddr,
+		IncentiveEligible:   ad.IncentiveEligible,
 		TotalAppSchema:      ad.TotalAppSchema,
 		TotalExtraAppPages:  ad.TotalExtraAppPages,
 		TotalAssetParams:    ad.TotalAssetParams,
@@ -656,14 +664,15 @@ func convertTrimmedLcAccountData(ad sdk.AccountData) baseAccountData {
 		TotalAppLocalStates: ad.TotalAppLocalStates,
 		TotalBoxes:          ad.TotalBoxes,
 		TotalBoxBytes:       ad.TotalBoxBytes,
-		baseOnlineAccountData: baseOnlineAccountData{
-			VoteID:          ad.VoteID,
-			SelectionID:     ad.SelectionID,
-			StateProofID:    ad.StateProofID,
-			VoteFirstValid:  ad.VoteFirstValid,
-			VoteLastValid:   ad.VoteLastValid,
-			VoteKeyDilution: ad.VoteKeyDilution,
-		},
+		LastProposed:        ad.LastProposed,
+		LastHeartbeat:       ad.LastHeartbeat,
+
+		VoteID:          ad.VoteID,
+		SelectionID:     ad.SelectionID,
+		StateProofID:    ad.StateProofID,
+		VoteFirstValid:  ad.VoteFirstValid,
+		VoteLastValid:   ad.VoteLastValid,
+		VoteKeyDilution: ad.VoteKeyDilution,
 	}
 }
 
@@ -672,6 +681,7 @@ func unconvertTrimmedLcAccountData(ba baseAccountData) sdk.AccountData {
 		AccountBaseData: sdk.AccountBaseData{
 			Status:              ba.Status,
 			AuthAddr:            ba.AuthAddr,
+			IncentiveEligible:   ba.IncentiveEligible,
 			TotalAppSchema:      ba.TotalAppSchema,
 			TotalExtraAppPages:  ba.TotalExtraAppPages,
 			TotalAppParams:      ba.TotalAppParams,
@@ -680,6 +690,8 @@ func unconvertTrimmedLcAccountData(ba baseAccountData) sdk.AccountData {
 			TotalAssets:         ba.TotalAssets,
 			TotalBoxes:          ba.TotalBoxes,
 			TotalBoxBytes:       ba.TotalBoxBytes,
+			LastProposed:        ba.LastProposed,
+			LastHeartbeat:       ba.LastHeartbeat,
 		},
 		VotingData: sdk.VotingData{
 			VoteID:          ba.VoteID,

--- a/plugin/exporter/idb/cockroach/internal/encoding/types.go
+++ b/plugin/exporter/idb/cockroach/internal/encoding/types.go
@@ -9,7 +9,11 @@ type AlgodEncodedAddress sdk.Address
 
 type blockHeader struct {
 	sdk.BlockHeader
+	// these "override" fields are used to encode these arrays of addresses as
+	// human-readable strings, instead of base64.
+	ProposerOverride                     AlgodEncodedAddress   `codec:"prp"`
 	ExpiredParticipationAccountsOverride []AlgodEncodedAddress `codec:"partupdrmv"`
+	AbsentParticipationAccountsOverride  []AlgodEncodedAddress `codec:"partupdabs"`
 }
 
 type assetParams struct {
@@ -87,22 +91,12 @@ type appParams struct {
 	GlobalStateOverride tealKeyValue `codec:"gs"`
 }
 
-type baseOnlineAccountData struct {
-	_struct struct{} `codec:",omitempty,omitemptyarray"`
-
-	VoteID          sdk.OneTimeSignatureVerifier `codec:"vote"`
-	SelectionID     sdk.VRFVerifier              `codec:"sel"`
-	StateProofID    sdk.Commitment               `codec:"stprf"`
-	VoteFirstValid  sdk.Round                    `codec:"voteFst"`
-	VoteLastValid   sdk.Round                    `codec:"voteLst"`
-	VoteKeyDilution uint64                       `codec:"voteKD"`
-}
-
 type baseAccountData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	Status              sdk.Status      `codec:"onl"`
 	AuthAddr            sdk.Address     `codec:"spend"`
+	IncentiveEligible   bool            `codec:"ie"`
 	TotalAppSchema      sdk.StateSchema `codec:"tsch"`
 	TotalExtraAppPages  uint32          `codec:"teap"`
 	TotalAssetParams    uint64          `codec:"tasp"`
@@ -112,5 +106,13 @@ type baseAccountData struct {
 	TotalBoxes          uint64          `codec:"tbx"`
 	TotalBoxBytes       uint64          `codec:"tbxb"`
 
-	baseOnlineAccountData
+	LastProposed  sdk.Round `codec:"lpr"`
+	LastHeartbeat sdk.Round `codec:"lhb"`
+
+	VoteID          sdk.OneTimeSignatureVerifier `codec:"vote"`
+	SelectionID     sdk.VRFVerifier              `codec:"sel"`
+	StateProofID    sdk.Commitment               `codec:"stprf"`
+	VoteFirstValid  sdk.Round                    `codec:"voteFst"`
+	VoteLastValid   sdk.Round                    `codec:"voteLst"`
+	VoteKeyDilution uint64                       `codec:"voteKD"`
 }


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/AlgoNode/conduit-cockroachdb/issues/4

This pull request updates type definitions in the encoding package to be in sync with `github.com/algorand/indexer/idb/postgres/internal/encoding`.

The types imported by the `encoding` package were also verified to be in sync.

Also, files in the `idb` package's root were verified to be in sync.